### PR TITLE
Hotfix

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -526,6 +526,8 @@ cp /usr/share/icons/nitrux_snow_cursors/index.theme /etc/X11/cursors/nitrux_curs
 ln -svf /etc/X11/cursors/nitrux_cursors.theme /etc/alternatives/x-cursor-theme
 sed -i '$ a Inherits=nitrux_snow_cursors' /etc/X11/cursors/nitrux_cursors.theme
 
+cp /boot/initrd.img /boot/initrd.img-generic
+
 rm -r /home/travis
 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -103,12 +103,12 @@ apt -qq -o=Dpkg::Use-Pty=0 -yy install $GLIBC_2_30_PKG --no-install-recommends -
 puts "ADDING ELOGIND."
 
 ELOGIND_PKGS='
-	bsdutils=1:2.35.2-2+devuan1
+	bsdutils
 	elogind
 	libelogind0
 	libprocps7
-	util-linux=2.35.2-2+devuan1
-	uuid-runtime=2.35.2-2+devuan1
+	util-linux
+	uuid-runtime
 '
 
 UPDT_APT_PKGS='

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -112,9 +112,9 @@ ELOGIND_PKGS='
 '
 
 UPDT_APT_PKGS='
-	apt=2.1.2+devuan1
-	apt-transport-https=2.1.2+devuan1
-	apt-utils=2.1.2+devuan1
+	apt
+	apt-transport-https
+	apt-utils
 '
 
 REMOVE_SYSTEMD_PKGS='

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -368,17 +368,27 @@ apt -qq -o=Dpkg::Use-Pty=0 -yy install $UPDT_KDE_PKGS $UPDT_KF5_LIBS $UPDT_MISC_
 apt -qq -o=Dpkg::Use-Pty=0 -yy --fix-broken install
 
 
-#	Upgrade and install misc. packages.
+#	Upgrade glibc packages.
 
 puts "UPGRADING/INSTALLING MISC. PACKAGES."
 
-cp /configs/files/sources.list.groovy /etc/apt/sources.list.d/ubuntu-groovy-repo.list
+cp /configs/files/sources.list.focal /etc/apt/sources.list.d/ubuntu-focal-repo.list
 
 UPDT_GLBIC_PKGS='
 	libc-bin
 	libc6
 	locales
 '
+
+apt -qq update
+apt -qq -o=Dpkg::Use-Pty=0 -yy install $UPDT_GLBIC_PKGS --only-upgrade
+
+rm /etc/apt/sources.list.d/ubuntu-focal-repo.list
+
+
+#	Upgrade and install misc. packages.
+
+cp /configs/files/sources.list.groovy /etc/apt/sources.list.d/ubuntu-groovy-repo.list
 
 OTHER_MISC_PKGS='
 	gamemode
@@ -397,8 +407,7 @@ UPDT_MISC_PKGS='
 '
 
 apt -qq update
-apt -qq -o=Dpkg::Use-Pty=0 -yy install $UPDT_GLBIC_PKGS $UPDT_MISC_PKGS --only-upgrade
-apt -qq -o=Dpkg::Use-Pty=0 -yy install $OTHER_MISC_PKGS --no-install-recommends
+apt -qq -o=Dpkg::Use-Pty=0 -yy install $OTHER_MISC_PKGS $UPDT_MISC_PKGS --no-install-recommends
 
 
 #	Install the kernel.

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 #	Exit on errors.
 
-set -e
+set -xe
 
 
 #	base image URL.
@@ -83,6 +83,7 @@ mkdir -p $iso_dir/boot
 
 cp $(echo $build_dir/boot/vmlinuz* | tr " " "\n" | sort | tail -n 1) $iso_dir/boot/kernel
 cp $(echo $build_dir/boot/initrd*  | tr " " "\n" | sort | tail -n 1) $iso_dir/boot/initramfs
+cp $(echo $build_dir/boot/initrd.img-generic  | tr " " "\n" | sort | tail -n 1) $iso_dir/boot/initramfs-generic
 
 rm -f $build_dir/boot/*
 

--- a/configs/files/grub.cfg
+++ b/configs/files/grub.cfg
@@ -10,7 +10,7 @@ set theme=/boot/grub/themes/nitrux/theme.txt
 menuentry "Boot Nitrux (Generic)" {
     set gfxpayload=keep
     linux /boot/kernel boot=casper libahci.ignore_sss=1 nopersistent noprompt quiet splash elevator=noop iso-scan/filename=$iso_path ZNX_OVERLAYS=/etc,/home,/var/lib/flatpak ZNX_DEV_UUID=$znx_dev_uuid radeon.cik_support=0 amdgpu.cik_support=1 radeon.si_support=0 amdgpu.si_support=1 username=user hostname=host locale=en_US.UTF-8
-    initrd /boot/initramfs
+    initrd /boot/initramfs-generic
     init=/sbin/openrc-init
 }
 
@@ -61,6 +61,6 @@ menuentry "Boot Nitrux (AMD)" {
 menuentry "Boot Nitrux in full-debug mode" {
     set gfxpayload=keep
     linux /boot/kernel boot=casper libahci.ignore_sss=1 nopersistent noprompt elevator=noop iso-scan/filename=$iso_path ZNX_OVERLAYS=/etc,/home,/var/lib/flatpak ZNX_DEV_UUID=$znx_dev_uuid radeon.cik_support=0 amdgpu.cik_support=1 radeon.si_support=0 amdgpu.si_support=1 username=user hostname=host locale=en_US.UTF-8
-    initrd /boot/initramfs
+    initrd /boot/initramfs-generic
     init=/sbin/openrc-init
 }


### PR DESCRIPTION
- This MR installs version 2.31-0ubuntu9 of `libc6` instead of 2.31-0ubuntu10 as it was initially. This package was replaced because it brakes software installed using PNX.